### PR TITLE
Mobile+Font CSS tweaks

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -12,6 +12,7 @@ body {
     background-color: #fff;
     color: #000;
     font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+    font-size: 1rem;
 
 }
 
@@ -28,7 +29,6 @@ img {
 }
 
 li {
-    font-size: 18pt;
     line-height: 1.5;
 }
 
@@ -40,8 +40,12 @@ ul {
 }
 
 section {
-    font-size: 2rem;
+    font-size: 1.5em;
     padding: 20px 30% 20px var(--body-padding);
+}
+
+section li {
+    font-size: 0.8em;
 }
 
 menu {
@@ -53,14 +57,14 @@ menu {
 
 nav {
     background-color: #fff;
-    font-size: 1rem;
+    font-size: 1em;
     position: sticky;
     top: 0;
 }
 
 nav li {
     display: inline;
-    font-size: 1rem;
+    font-size: 1em;
 }
 
 nav li:not(:first-child)::before {
@@ -160,6 +164,10 @@ footer {
 @media (max-width: 400px) {
     :root {
         --body-padding: 30px;
+    }
+
+    body {
+        font-size: 14px
     }
 
     section {

--- a/src/main.css
+++ b/src/main.css
@@ -8,12 +8,14 @@
     --body-padding: 50px;
 }
 
+html {
+    font-size: 1.25rem;
+}
+
 body {
     background-color: #fff;
     color: #000;
     font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-    font-size: 1rem;
-
 }
 
 p {
@@ -40,12 +42,12 @@ ul {
 }
 
 section {
-    font-size: 1.5em;
+    font-size: 1.5rem;
     padding: 20px 30% 20px var(--body-padding);
 }
 
 section li {
-    font-size: 0.8em;
+    font-size: 1rem;
 }
 
 menu {
@@ -57,14 +59,14 @@ menu {
 
 nav {
     background-color: #fff;
-    font-size: 1em;
+    font-size: 1rem;
     position: sticky;
     top: 0;
 }
 
 nav li {
     display: inline;
-    font-size: 1em;
+    font-size: 1rem;
 }
 
 nav li:not(:first-child)::before {
@@ -166,8 +168,8 @@ footer {
         --body-padding: 30px;
     }
 
-    body {
-        font-size: 14px
+    html {
+        font-size: 1rem;
     }
 
     section {

--- a/src/main.css
+++ b/src/main.css
@@ -48,12 +48,12 @@ menu {
     display: flex;
     overflow-x: auto;
     white-space: nowrap;
+    padding: 20px var(--body-padding);
 }
 
 nav {
     background-color: #fff;
     font-size: 1rem;
-    padding: 20px var(--body-padding);
     position: sticky;
     top: 0;
 }


### PR DESCRIPTION
Some small-ish layout+font tweaks.  
Summary of changes:

- Makes the nav bar scrolling more suitable for mobile (now it's functionally more similar to the way grapheneos.org's nav bar seems to work on mobile).
- Tweaks the font-sizes of everything (see commit message for more details).
- Gives mobile a more suitable font-size. Though it might be better to change it to `1rem` rather than `14px`.